### PR TITLE
Fix false positive in `is_tag`

### DIFF
--- a/LMS/Message/Tags.py
+++ b/LMS/Message/Tags.py
@@ -50,7 +50,7 @@ class Tag_Utility:
         """Returns if a message is a tag.
 
         :param `message`: The message to check."""
-        if message.startswith("<") and message.endswith(">"):
+        if not message.startswith("<\\") and message.startswith("<") and message.endswith(">"):
             return True
 
         return False


### PR DESCRIPTION
This PR aims to fix a false positive that could occur when identifying sections of a message as a MessageStudio tag.

Take for example this message from Tomodachi Collection Shin Seikatsu:
```json
"touch_react_food_ultrabest_shout": "<\\Ecg=80><\\Ecl=3000><\\Spd=300>ウマーーーーーーイ\u0000",
```
```
<\Ecg=80><\Ecl=3000><\Spd=300>ウマーーーーーーイ
```
These are not MS tags, but PylibMS would still try to parse them as such.

Let me know if there's a better way to implement this fix.
